### PR TITLE
Added new features

### DIFF
--- a/ninja/build.go
+++ b/ninja/build.go
@@ -9,20 +9,21 @@ import (
 )
 
 type buildContext struct {
-	stagingHost   string
-	stagingDocker string
-
-	outputDocker string
-
-	archBinaries map[string]string
-
+	stagingHost      string
+	stagingDocker    string
+	outputDocker     string
+	archBinaries     map[string]string
 	dockerVolumeArgs []string
 }
 
 func doBuild(arguments map[string]interface{}) {
-       if arguments["verbose"] != nil {
-               verbose = true
-       }
+	if arguments["verbose"] != nil {
+		verbose = true
+	}
+
+	// Where should this driver / app get installed to? Default is /opt/ninjablocks
+	deployPath = arguments["--debian-install-path"].(string)
+
 	path := arguments["<path>"].(string)
 
 	pkg, err := NewNinjaPackage(path)
@@ -30,9 +31,20 @@ func doBuild(arguments map[string]interface{}) {
 		log.Fatalf("Could not parse package metadata: %v\n", err)
 	}
 
-	color.Printf("@bPackage name: @|%v\n", pkg.Name())
-	color.Printf("@bShort name:   @|%v\n", pkg.ShortName())
-	color.Printf("@bVersion:      @|%v\n", pkg.Version())
+	switch arguments["--build-type"].(string) {
+	case "snappy":
+		color.Printf("@bBuild type:    @|Snappy Only\n")
+	case "deb":
+		color.Printf("@bBuild type:    @|Deb Only\n")
+	case "all":
+		color.Printf("@bBuild type:    @|Deb and Snappy\n")
+	}
+
+	color.Printf("@bPackage Type:  @|%s\n", arguments["--package-type"].(string))
+	color.Printf("@bDeploy path:   @|%s\n", deployPath)
+	color.Printf("@bPackage name:  @|%v\n", pkg.Name())
+	color.Printf("@bShort name:    @|%v\n", pkg.ShortName())
+	color.Printf("@bVersion:       @|%v\n", pkg.Version())
 
 	dockerArgs := []string{
 		"-v", pkg.BasePath + ":/home/builder/go/src/ninja-dev-cli/" + pkg.ShortName(),
@@ -44,38 +56,40 @@ func doBuild(arguments map[string]interface{}) {
 
 	fullPath := "/home/builder/go/src/ninja-dev-cli/" + pkg.ShortName()
 
-	// Perform Intel magic
-	cmdIntel := []string{
-		"/bin/bash", "-c",
-		"GOPATH=" + fullPath + "/.gopath-cli:$GOPATH; (" +
-			"go get -d ninja-dev-cli/" + pkg.ShortName() + ";" +
-			"go build -o " + fullPath + "/.gopath-cli/autoclibinary-amd64 ninja-dev-cli/" + pkg.ShortName() + ";" +
-			")",
+	if arguments["--build-type"].(string) == "snappy" || arguments["--build-type"].(string) == "all" {
+
+		// Perform Intel magic
+		cmdIntel := []string{
+			"/bin/bash", "-c",
+			"GOPATH=" + fullPath + "/.gopath-cli:$GOPATH; (" +
+				"go get -d ninja-dev-cli/" + pkg.ShortName() + ";" +
+				"go build -o " + fullPath + "/.gopath-cli/autoclibinary-amd64 ninja-dev-cli/" + pkg.ShortName() + ";" +
+				")",
+		}
+
+		color.Printf("@cCompiling for architecture: amd64\n")
+		runNativeDockerCrossCommand(dockerArgs, cmdIntel...)
+
+		// Perform ARM magic
+		cmdARM := []string{
+			"/bin/bash", "-c",
+			"(" +
+				"sed -i '/source-root-users/d' /etc/schroot/chroot.d/click-ubuntu-sdk-14.04-armhf; " +
+				"click chroot -aarmhf -fubuntu-sdk-14.04 -s trusty run " +
+				"CGO_ENABLED=1 GOARCH=arm GOARM=7 " +
+				"PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig " +
+				"CC=arm-linux-gnueabihf-gcc " +
+				"GOPATH=" + fullPath + "/.gopath-cli:$GOPATH " +
+				"go build -ldflags '-extld=arm-linux-gnueabihf-gcc' " +
+				"-o " + fullPath + "/.gopath-cli/autoclibinary-armhf ninja-dev-cli/" + pkg.ShortName() + ";" +
+				")",
+		}
+
+		color.Printf("@cCompiling for architecture: armhf\n")
+		runNativeDockerCrossCommand(dockerArgs, cmdARM...)
+
+		fmt.Printf("\n")
 	}
-
-	color.Printf("@cCompiling for architecture: amd64\n")
-	runNativeDockerCrossCommand(dockerArgs, cmdIntel...)
-
-	// Perform ARM magic
-	cmdARM := []string{
-		"/bin/bash", "-c",
-		"(" +
-			"sed -i '/source-root-users/d' /etc/schroot/chroot.d/click-ubuntu-sdk-14.04-armhf; " +
-			"click chroot -aarmhf -fubuntu-sdk-14.04 -s trusty run " +
-			"CGO_ENABLED=1 GOARCH=arm GOARM=7 " +
-			"PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig " +
-			"CC=arm-linux-gnueabihf-gcc " +
-			"GOPATH=" + fullPath + "/.gopath-cli:$GOPATH " +
-			"go build -ldflags '-extld=arm-linux-gnueabihf-gcc' " +
-			"-o " + fullPath + "/.gopath-cli/autoclibinary-armhf ninja-dev-cli/" + pkg.ShortName() + ";" +
-			")",
-	}
-
-	color.Printf("@cCompiling for architecture: armhf\n")
-	runNativeDockerCrossCommand(dockerArgs, cmdARM...)
-
-	fmt.Printf("\n")
-
 	/** Package **/
 
 	context := &buildContext{}
@@ -99,12 +113,16 @@ func doBuild(arguments map[string]interface{}) {
 	// and recreate ready to fill
 	os.MkdirAll(context.stagingHost, 0750)
 
-	// build for all archs for now
-	for _, arch := range []string{"amd64", "armhf"} {
-		color.Printf("@mCreating Snappy package for architecture: %v\n", arch)
-		buildSnappyPackage(pkg, context, arch, arguments)
+	if arguments["--build-type"].(string) == "snappy" || arguments["--build-type"].(string) == "all" {
+		// build for all archs for now
+		for _, arch := range []string{"amd64", "armhf"} {
+			color.Printf("@mCreating Snappy package for architecture: %v\n", arch)
+			buildSnappyPackage(pkg, context, arch, arguments)
+		}
 	}
 
-	color.Printf("@mCreating Debian package for architecture: %v\n", "armhf")
-	buildDebianPackage(pkg, context, "armhf")
+	if arguments["--build-type"].(string) == "deb" || arguments["--build-type"].(string) == "all" {
+		color.Printf("@mCreating Debian package for architecture: %v\n", "armhf")
+		buildDebianPackage(pkg, context, "armhf")
+	}
 }

--- a/ninja/debianBuild.go
+++ b/ninja/debianBuild.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/termie/go-shutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/termie/go-shutil"
 )
 
 type upstartTemplateVars struct {
@@ -34,6 +35,7 @@ func buildDebianPackage(pkg *NinjaPackage, ctx *buildContext, arch string) {
 
 	// binary itself
 	binCurr := filepath.Join(targetPath, pkg.ShortName())
+	fmt.Println(ctx.archBinaries[arch], binCurr)
 	shutil.Copy(ctx.archBinaries[arch], binCurr, false)
 
 	// package.json
@@ -41,8 +43,17 @@ func buildDebianPackage(pkg *NinjaPackage, ctx *buildContext, arch string) {
 	pkgCurr := filepath.Join(targetPath, "package.json")
 	shutil.Copy(srcFile, pkgCurr, true) // don't copy symlink itself, just the real file
 
+	// Copy all of the files in package.json into the same dir as the binary. TO-DO: Fix this so you can copy to the binary folder, or other places like the icons folder in /data
 	for _, fn := range pkg.PathsToCopy() {
-		shutil.Copy(fn, targetPath, true) // don't copy symlink itself, just the real file
+		srcPath := filepath.Join(pkg.BasePath, fn)
+		dstPath := filepath.Join(targetPath, fn)
+		err := copyAnything(srcPath, dstPath)
+
+		if err != nil {
+			// Can't copy the files? Panic!
+			panic(err)
+		}
+
 	}
 
 	tplData := &upstartTemplateVars{

--- a/ninja/debianTemplates.go
+++ b/ninja/debianTemplates.go
@@ -15,7 +15,7 @@ env APP={{.PackageName}}
 env LOG=/var/log/{{.PackageName}}.log
 env PID=/var/run/{{.PackageName}}.pid
 
-env NINJA_APP_PATH=/opt/ninjablocks/{{.TargetDir}}/{{.PackageName}}
+env NINJA_APP_PATH={{.BaseDir}}/{{.TargetDir}}/{{.PackageName}}
 env NINJA_APP_DATA_PATH=/data/sphere/appdata/{{.TargetDir}}/{{.PackageName}}
 
 script

--- a/ninja/globals.go
+++ b/ninja/globals.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/termie/go-shutil"
 	"os"
+
+	"github.com/termie/go-shutil"
 )
 
 var verbose = false

--- a/ninja/globals.go
+++ b/ninja/globals.go
@@ -1,3 +1,24 @@
 package main
 
-var verbose bool = false
+import (
+	"github.com/termie/go-shutil"
+	"os"
+)
+
+var verbose = false
+var arguments map[string]interface{}
+var deployPath string
+
+func copyAnything(from string, to string) error {
+	fromStat, err := os.Stat(from)
+	if err != nil {
+		return err
+	}
+
+	if fromStat.IsDir() {
+		return shutil.CopyTree(from, to, nil)
+	} else {
+		_, err = shutil.Copy(from, to, true)
+		return err
+	}
+}

--- a/ninja/main.go
+++ b/ninja/main.go
@@ -14,7 +14,7 @@ Options:
   build                                 Builds a package for a driver or app, ready for distribution to the Ninja Sphere.
 	--debian-install-path=<buildpath>     The deb version of this driver or app will be installed to this path. Include trailing slash [default: /opt/ninjablocks/]
 	--build-type=<buildtype>              What type of package should be built? Valid options are "deb", "snappy" or "all" [default: all]
-	--package-type=[auto|apps|drivers]       If the binary name starts with driver-, it'll deploy to <buildpath>/drivers, otherwise <buildpath>/apps. Use this to overwrite [default: auto]
+	--package-type=[auto|apps|drivers]    If the binary name starts with driver-, it'll deploy to <buildpath>/drivers, otherwise <buildpath>/apps. Use this to overwrite [default: auto]
   --snappy-namespace=<ns>               Set the namespace for the Snappy package.
   -v --verbose                          Verbose
   -h --help                             Show this screen.

--- a/ninja/main.go
+++ b/ninja/main.go
@@ -11,17 +11,19 @@ Usage:
   ninja -h | --help
 
 Options:
-  build                     Builds a package for a driver or app, ready for distribution to the Ninja Sphere.
-  --snappy-namespace=<ns>   Set the namespace for the Snappy package.
-  -v --verbose              Verbose
-  -h --help                 Show this screen.
+  build                                 Builds a package for a driver or app, ready for distribution to the Ninja Sphere.
+	--debian-install-path=<buildpath>     The deb version of this driver or app will be installed to this path. Include trailing slash [default: /opt/ninjablocks/]
+	--build-type=<buildtype>              What type of package should be built? Valid options are "deb", "snappy" or "all" [default: all]
+	--package-type=[auto|apps|drivers]       If the binary name starts with driver-, it'll deploy to <buildpath>/drivers, otherwise <buildpath>/apps. Use this to overwrite [default: auto]
+  --snappy-namespace=<ns>               Set the namespace for the Snappy package.
+  -v --verbose                          Verbose
+  -h --help                             Show this screen.
 `
 
 func main() {
-	arguments, _ := docopt.Parse(usage, nil, true, "Ninja Sphere Developer CLI", false)
 
+	arguments, _ = docopt.Parse(usage, nil, true, "Ninja Sphere Developer CLI", false)
 	verifyDockerImages()
-
 	if arguments["build"].(bool) {
 		doBuild(arguments)
 	}

--- a/ninja/snappyBuild.go
+++ b/ninja/snappyBuild.go
@@ -106,17 +106,3 @@ func buildSnappyPackage(pkg *NinjaPackage, ctx *buildContext, arch string, argum
 		panic("Multi-arch snaps not supported yet, FIXME add shim wrapper here")
 	}
 }
-
-func copyAnything(from string, to string) error {
-	fromStat, err := os.Stat(from)
-	if err != nil {
-		return err
-	}
-
-	if fromStat.IsDir() {
-		return shutil.CopyTree(from, to, nil)
-	} else {
-		_, err = shutil.Copy(from, to, true)
-		return err
-	}
-}


### PR DESCRIPTION
Added:
--debian-install-path - lets you set where the binary gets installed
(default /opt/ninjablocks),
--build-type - lets you build either deb packages only, snappy packages
only, or both (default).
--package-type - lets you manually override package type (e.g. you can
make a package that starts with driver- and install it to /opt/ninjablocks/apps
instead)

Also made buildDebianPackage copy over and compile files in package.json
